### PR TITLE
Add global default error handler

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -240,6 +240,19 @@ Names are the same as the local handlers:
     .get()
 ```
 
+A global `default` handler catches anything that no other handler does. A request-level `.default()` takes precedence over it, but global status handlers (such as `notFound`) do not check it.
+
+```js
+  Api.configure({
+    baseUrl: 'https://example.com/your/api/base',
+    handlers: {
+      default (e) {
+        throw error(500, e.message)
+      }
+    }
+  })
+```
+
 ## Retries
 
 The http client can retry if a network error is encountered. The default is `retry: false`, and requests won't be retried.

--- a/lib/index.js
+++ b/lib/index.js
@@ -179,6 +179,7 @@ class Api {
     const handler = this.handlers[constructorName] ||
       (this.options.handlers && this.options.handlers[globalHandlerName]) ||
       this.defaultHandler ||
+      (this.options.handlers && this.options.handlers.default) ||
       ((e) => {
         console.error(constructorName, e.message, e)
       })

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -162,6 +162,66 @@ describe('util/api', () => {
         expect(globalCalled).to.be.true()
         expect(defaultCalled).to.be.false()
       })
+
+      it('falls back to global default handler', async () => {
+        let received
+
+        const api = new Api({
+          baseUrl: 'https://example.com/api/v1',
+          handlers: {
+            default: (e) => {
+              received = e
+              return 'fallback'
+            }
+          }
+        })
+
+        clientStub.resolves({
+          ok: false,
+          statusText: 'No',
+          json: stub().resolves({ error: 'no' }),
+          status: 404,
+          headers: new Map()
+        })
+
+        const result = await api
+          .context({ fetch: clientStub })
+          .endpoint('some/url')
+          .get()
+
+        expect(result).to.equal('fallback')
+        expect(received.body).to.equal({ error: 'no' })
+      })
+
+      it('prefers request default handler to global default handler', async () => {
+        let globalCalled = false
+
+        const api = new Api({
+          baseUrl: 'https://example.com/api/v1',
+          handlers: {
+            default: () => {
+              globalCalled = true
+            }
+          }
+        })
+
+        clientStub.resolves({
+          ok: false,
+          statusText: 'No',
+          json: stub().resolves({ error: 'no' }),
+          status: 404,
+          headers: new Map()
+        })
+
+        const result = await api
+          .context({ fetch: clientStub })
+          .endpoint('some/url')
+          .default(() => 'local')
+          .get()
+
+        expect(result).to.equal('local')
+        expect(globalCalled).to.be.false()
+      })
     })
 
     context('responds ok', () => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -76,6 +76,8 @@ export type ErrorHandlers = {
   expectationFailed?: ErrorHandler;
   badData?: ErrorHandler;
   tooManyRequests?: ErrorHandler;
+  /** Called when no request-level or status-specific handler matches */
+  default?: ErrorHandler;
   [key: string]: ErrorHandler | undefined;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beyonk/http",
-  "version": "12.2.0",
+  "version": "12.3.0",
   "description": "An isomorphic http client for Svelte apps",
   "type": "module",
   "repository": "https://github.com/beyonk/http.git",


### PR DESCRIPTION
## What

Adds a `default` entry to the global `handlers` passed to `Api.configure()`. It is called when a failed request has no request-level or status-specific handler, instead of the library logging to `console.error` and resolving to `undefined`.

```js
Api.configure({
  baseUrl,
  handlers: {
    accessDenied: forceReauthenticate,
    default: e => error(e.body?.statusCode ?? 500, e.body?.message ?? e.message)
  }
})
```

## Precedence

1. Request-level status handler (`.notFound(fn)`)
2. Global status handler (`handlers.notFound`)
3. Request-level `.default(fn)`
4. Global `handlers.default` (new)
5. `console.error` fallback

Existing behaviour is unchanged. The new handler only fills the slot that previously fell through to the console.

## Why

In the dashboard, around 160 request chains have no error handler. A failed request resolves to `undefined` and callers then throw a `TypeError` on destructuring, so users see a generic 500 rather than the API's status and message. A global default lets one line in the app's http client fix that without touching every chain.

## Changes

- `lib/index.js`: consult `options.handlers.default` after `defaultHandler`
- `lib/types.ts`: add `default?: ErrorHandler` to `ErrorHandlers`
- `README.MD`: document the global default under "At a global level"
- `lib/index.spec.js`: two cases, falls back to the global default and request-level default takes precedence
- `package.json`: 12.2.0 to 12.3.0

## Checks

- `pnpm test`: 50 passing
- `pnpm build`: succeeds
- `pnpm lint`: 3 pre-existing stylistic errors at spec lines 344 and 350, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
