### PR TITLE
Attach status and request details to errors

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -192,6 +192,8 @@ Handlers have a signature with two items:
 })
 ```
 
+Every error carries the request that failed as `e.request` (`{ method, url }`), and HTTP failures also carry `e.status` and the parsed response as `e.body`. Errors thrown by `fetch` itself, such as network failures or aborts, have `e.request` but no `e.status`.
+
 ctx can be whatever you want really - it is whatever you pass in as `context(...)`.
 
 However, if the `context` object you pass in has a `fetch` function, this is used as the `fetch` for XHR requests.

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,10 +19,14 @@ export class HttpError extends Error {
    * Create a new HTTP error
    * @param {string} message - Error message
    * @param {any} body - Error response body
+   * @param {number} [status] - HTTP status code, absent when the request never got a response
    */
-  constructor (message, body) {
+  constructor (message, body, status) {
     super(message)
     this.body = body
+    this.status = status
+    /** @type {{ method: string, url: string } | undefined} The request that failed */
+    this.request = undefined
   }
 }
 
@@ -223,7 +227,7 @@ class Api {
     try {
       result = await this.#doQuery(1, client, ep, options)
     } catch (e) {
-      console.log(e)
+      e.request = { method: options.method, url: ep }
       // @ts-ignore
       return this.handle(e, this.ctx)
     } finally {
@@ -289,7 +293,7 @@ class Api {
       }
 
       const ClientError = getErrorByCode(r.status)
-      throw new ClientError(r.statusText, content)
+      throw new ClientError(r.statusText, content, r.status)
     } catch (e) {
       // @ts-ignore
       if (retry.attempts && retry.errors && attempt < retry.attempts && retry.errors.includes(e.code)) {

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -222,6 +222,58 @@ describe('util/api', () => {
         expect(result).to.equal('local')
         expect(globalCalled).to.be.false()
       })
+
+      it('attaches the status and request to http errors', async () => {
+        let received
+
+        const api = new Api({
+          baseUrl: 'https://example.com/api/v1'
+        })
+
+        clientStub.resolves({
+          ok: false,
+          statusText: 'No',
+          json: stub().resolves({ error: 'no' }),
+          status: 404,
+          headers: new Map()
+        })
+
+        await api
+          .context({ fetch: clientStub })
+          .endpoint('some/url')
+          .query({ page: 2 })
+          .default(e => {
+            received = e
+          })
+          .get()
+
+        expect(received.status).to.equal(404)
+        expect(received.body).to.equal({ error: 'no' })
+        expect(received.request).to.equal({ method: 'GET', url: 'https://example.com/api/v1/some/url?page=2' })
+      })
+
+      it('attaches the request to errors thrown by fetch', async () => {
+        let received
+
+        const api = new Api({
+          baseUrl: 'https://example.com/api/v1'
+        })
+
+        clientStub.rejects(new TypeError('fetch failed'))
+
+        await api
+          .context({ fetch: clientStub })
+          .endpoint('some/url')
+          .payload({ a: 1 })
+          .default(e => {
+            received = e
+          })
+          .post()
+
+        expect(received.message).to.equal('fetch failed')
+        expect(received.status).to.be.undefined()
+        expect(received.request).to.equal({ method: 'POST', url: 'https://example.com/api/v1/some/url' })
+      })
     })
 
     context('responds ok', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beyonk/http",
-  "version": "12.4.2",
+  "version": "12.5.0",
   "description": "An isomorphic http client for Svelte apps",
   "type": "module",
   "repository": "https://github.com/beyonk/http.git",


### PR DESCRIPTION
## What

Errors handed to handlers now carry enough to log them without help from the call site:

- `e.status`: the HTTP status code. `HttpError` takes it as a third constructor argument and `#doQuery` passes `r.status`. Absent for errors thrown by `fetch` itself.
- `e.request`: `{ method, url }` of the request that failed, stamped in `send()` onto anything caught, so network failures and aborts carry it too.

```js
.default(e => {
  logger.error({ status: e.status, method: e.request.method, url: e.request.url }, 'API request failed')
})
```

Also removes the bare `console.log(e)` in `send()`. Applications log through their handlers, so it only produced a second, context-free copy of every failure on stdout.

## Why

The dashboard now logs handled API failures to Better Stack (beyonk/dashboard#2358). Without this change those log lines have no endpoint, and no status when the API body isn't JSON, such as a 502 or 504 from the gateway.

## Changes

- `lib/index.js`: `HttpError` gains `status` and `request`; `send()` stamps `request` and drops the `console.log`; `#doQuery` passes the status
- `README.MD`: note under the handler signature
- `lib/index.spec.js`: two cases, an HTTP failure carries status, body and request; a fetch rejection carries request and no status
- `package.json`: 12.4.2 to 12.5.0

## Checks

- `pnpm test`: 52 passing
- `pnpm build`: succeeds; generated `index.d.ts` declares `status` and `request` on `HttpError`
- `pnpm lint`: the same 3 pre-existing stylistic errors in the spec, unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
