### PR TITLE
Log failures through the context logger before default handlers

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -198,6 +198,8 @@ ctx can be whatever you want really - it is whatever you pass in as `context(...
 
 However, if the `context` object you pass in has a `fetch` function, this is used as the `fetch` for XHR requests.
 
+If it has a `logger` with an `error(details, message)` method, such as a pino logger, every failure that reaches a `default` handler (request-level or global) is logged through it before the handler runs, with `err`, `status`, `method`, `url` and `body`. Without one the console is used. Failures caught by a status-specific handler such as `.notFound()` are not logged.
+
 ```js
 export async function preload () {
   await Api

--- a/lib/index.js
+++ b/lib/index.js
@@ -180,15 +180,34 @@ class Api {
     const constructorName = Object.getPrototypeOf(e).constructor.name
     const globalHandlerName = `${constructorName[0].toLowerCase()}${constructorName.slice(1, -5)}`
 
-    const handler = this.handlers[constructorName] ||
-      (this.options.handlers && this.options.handlers[globalHandlerName]) ||
+    const specificHandler = this.handlers[constructorName] ||
+      (this.options.handlers && this.options.handlers[globalHandlerName])
+
+    const handler = specificHandler ||
       this.defaultHandler ||
       (this.options.handlers && this.options.handlers.default) ||
       ((e) => {
         console.error(constructorName, e.message, e)
       })
 
+    if (!specificHandler) {
+      this.log(e, ctx)
+    }
+
     return handler(e, ctx)
+  }
+
+  /**
+   * Log a failed request through the context logger, or the console
+   * @param {HttpError} e - Error instance
+   * @param {ApiContext} [ctx] - API context
+   */
+  log (e, ctx) {
+    const logger = (ctx && ctx.logger) || console
+    const { method, url } = e.request || {}
+    const reason = e.status ? `with ${e.status}` : `(${e.message})`
+
+    logger.error({ err: e, status: e.status, method, url, body: e.body }, `${method} ${url} failed ${reason}`)
   }
 
   /**

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -274,6 +274,81 @@ describe('util/api', () => {
         expect(received.status).to.be.undefined()
         expect(received.request).to.equal({ method: 'POST', url: 'https://example.com/api/v1/some/url' })
       })
+
+      it('logs through the context logger before the default handler runs', async () => {
+        const calls = []
+        const logger = { error: (details, message) => calls.push(['log', details, message]) }
+
+        const api = new Api({
+          baseUrl: 'https://example.com/api/v1'
+        })
+
+        clientStub.resolves({
+          ok: false,
+          statusText: 'No',
+          json: stub().resolves({ error: 'no' }),
+          status: 404,
+          headers: new Map()
+        })
+
+        await api
+          .context({ fetch: clientStub, logger })
+          .endpoint('some/url')
+          .default(() => calls.push(['handler']))
+          .get()
+
+        expect(calls.map(c => c[0])).to.equal([ 'log', 'handler' ])
+        const [ , details, message ] = calls[0]
+        expect(details.status).to.equal(404)
+        expect(details.method).to.equal('GET')
+        expect(details.url).to.equal('https://example.com/api/v1/some/url')
+        expect(details.body).to.equal({ error: 'no' })
+        expect(details.err).to.be.an.error()
+        expect(message).to.equal('GET https://example.com/api/v1/some/url failed with 404')
+      })
+
+      it('logs to the console when the context has no logger', async () => {
+        const consoleError = stub(console, 'error')
+
+        const api = new Api({
+          baseUrl: 'https://example.com/api/v1',
+          handlers: { default: () => 'handled' }
+        })
+
+        clientStub.rejects(new TypeError('fetch failed'))
+
+        try {
+          await api.context({ fetch: clientStub }).endpoint('some/url').get()
+          expect(consoleError.calledOnce).to.be.true()
+          expect(consoleError.firstCall.args[1]).to.equal('GET https://example.com/api/v1/some/url failed (fetch failed)')
+        } finally {
+          consoleError.restore()
+        }
+      })
+
+      it('does not log when a status-specific handler handles the error', async () => {
+        let logged = false
+
+        const api = new Api({
+          baseUrl: 'https://example.com/api/v1'
+        })
+
+        clientStub.resolves({
+          ok: false,
+          statusText: 'No',
+          json: stub().resolves({ error: 'no' }),
+          status: 404,
+          headers: new Map()
+        })
+
+        await api
+          .context({ fetch: clientStub, logger: { error: () => { logged = true } } })
+          .endpoint('some/url')
+          .notFound(() => null)
+          .get()
+
+        expect(logged).to.be.false()
+      })
     })
 
     context('responds ok', () => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,6 +52,8 @@ export type RequestConfig = {
 export type ApiContext = {
   /** Fetch client */
   fetch?: FetchClient;
+  /** Logger for failed requests, defaults to console */
+  logger?: { error: (details: Record<string, any>, message: string) => void };
   /** Additional context properties */
   [key: string]: any;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beyonk/http",
-  "version": "12.5.0",
+  "version": "12.6.0",
   "description": "An isomorphic http client for Svelte apps",
   "type": "module",
   "repository": "https://github.com/beyonk/http.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beyonk/http",
-  "version": "12.6.0",
+  "version": "12.5.0",
   "description": "An isomorphic http client for Svelte apps",
   "type": "module",
   "repository": "https://github.com/beyonk/http.git",


### PR DESCRIPTION
## What

When a failure reaches a `default` handler (request-level `.default()` or the global `handlers.default`), the client now logs it first, through `context.logger` if one was passed and the console otherwise:

```js
await Api.create()
  .context({ fetch, logger: locals.logger })
  .endpoint('passes/x')
  .default(() => null)
  .get()

// logger.error({ err, status: 404, method: 'GET', url: 'https://.../passes/x', body }, 'GET https://.../passes/x failed with 404')
```

The `logger` needs an `error(details, message)` method, which matches pino. Failures caught by a status-specific handler such as `.notFound()` are not logged, since the caller has chosen to handle that case.

## Why

Every `.default` handler in the dashboard was logging by hand (beyonk/dashboard#2358). Since 12.5.0 the error already carries the request and status, so the client can write one consistent log line itself.

## Changes

- `lib/index.js`: `handle()` logs via new `log(e, ctx)` before a default handler runs
- `lib/types.ts`: `logger` on `ApiContext`
- `README.MD`: paragraph under the handler signature
- `lib/index.spec.js`: three cases, logs before the handler with the expected fields, console fallback, no log for status-specific handlers

## Checks

- `pnpm test`: 55 passing
- `pnpm build`: succeeds
- `pnpm lint`: same 3 pre-existing stylistic errors in the spec, unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)